### PR TITLE
commonjs only, remove unicode lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 , "scripts": {
     "test": "./node_modules/.bin/mocha ./test/*.test.* --require should --reporter spec --colors --compilers coffee:coffee-script/register"}
 , "dependencies": {
-    "unicode": ">= 0.3.1"}
+    "unidecode": "0.1.8"
+}
 , "devDependencies": {
     "mocha": "~1.17.1",
     "should": "~3.1.2",

--- a/slug.js
+++ b/slug.js
@@ -1,15 +1,5 @@
-(function (root) {
-// lazy require symbols table
-var _symbols, removelist;
-function symbols(code) {
-    if (_symbols) return _symbols[code];
-    _symbols = require('unicode/category/So');
-    removelist = ['sign','cross','of','symbol','staff','hand','black','white']
-        .map(function (word) {return new RegExp(word, 'gi')});
-    return _symbols[code];
-}
-
 function slug(string, opts) {
+    unidecode = require('unidecode')
     string = string.toString();
     if ('string' === typeof opts)
         opts = {replacement:opts};
@@ -49,12 +39,8 @@ function slug(string, opts) {
             } else {
                 code = string.charCodeAt(i);
             }
-            if (opts.symbols && (unicode = symbols(code))) {
-                char = unicode.name.toLowerCase();
-                for(var j = 0, rl = removelist.length; j < rl; j++) {
-                    char = char.replace(removelist[j], '');
-                }
-                char = char.replace(/^\s+|\s+$/g, '');
+            if (opts.symbols) {
+                char = unidecode(char)
             }
         }
         char = char.replace(/[^\w\s\-\.\_~]/g, ''); // allowed
@@ -184,29 +170,4 @@ slug.defaults.modes = {
     },
 };
 
-// Be compatible with different module systems
-
-if (typeof define !== 'undefined' && define.amd) { // AMD
-    // dont load symbols table in the browser
-    for (var key in slug.defaults.modes) {
-        if (!slug.defaults.modes.hasOwnProperty(key))
-            continue;
-
-        slug.defaults.modes[key].symbols = false;
-    }
-    define([], function () {return slug});
-} else if (typeof module !== 'undefined' && module.exports) { // CommonJS
-    symbols(); // preload symbols table
-    module.exports = slug;
-} else { // Script tag
-    // dont load symbols table in the browser
-    for (var key in slug.defaults.modes) {
-        if (!slug.defaults.modes.hasOwnProperty(key))
-            continue;
-
-        slug.defaults.modes[key].symbols = false;
-    }
-    root.slug = slug;
-}
-
-}(this));
+module.exports = slug;

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -190,16 +190,9 @@ describe 'slug', ->
         for char in char_map
             [slug "foo #{char} bar baz"].should.eql ["foo-bar-baz"]
 
-    it.skip 'should replace unicode', ->
-        char_map = {
-            '☢':"radioactive",'☠':"skull-and-bones",'☤':"caduceus",
-            '☣':"biohazard",'☭':"hammer-and-sickle", '☯':"yin-yang",'☮':"peace",
-            '☏':"telephone",'☔':"umbrella-with-rain-drops",'☎':"telephone",
-            '☀':"sun-with-rays",'★':"star",'☂':"umbrella",'☃':"snowman",
-            '✈':"airplane",'✉':"envelope",'✊':"raised-fist"
-        }
-        for char, replacement of char_map
-            [slug "foo #{char} bar baz"].should.eql ["foo-#{replacement}-bar-baz"]
+    it 'should replace unicode', ->
+        slug('ひらがな abc 123 FOO').should.eql 'hiragana-abc-123-FOO'
+        slug('لماذا نعيش؟').should.eql 'lmdh-naaysh'
 
     it 'should replace no unicode when disabled', ->
         char_map = '😹☢☠☤☣☭☯☮☏☔☎☀★☂☃✈✉✊'.split ''
@@ -215,8 +208,8 @@ describe 'slug', ->
     it 'should replace lithuanian characters', ->
         slug('ąčęėįšųūžĄČĘĖĮŠŲŪŽ').should.eql 'aceeisuuzACEEISUUZ'
 
-    it.skip 'should replace multichars', ->
-        [slug "w/ <3 && sugar || ☠"].should.eql ['with-love-and-sugar-or-skull-and-bones']
+    it 'should replace multichars', ->
+        [slug "w/ <3 && sugar"].should.eql ['with-love-and-sugar']
 
     it 'should be flavourable', ->
         text = "It's your journey ... we guide you through."

--- a/test/slug.test.coffee
+++ b/test/slug.test.coffee
@@ -190,7 +190,7 @@ describe 'slug', ->
         for char in char_map
             [slug "foo #{char} bar baz"].should.eql ["foo-bar-baz"]
 
-    it 'should replace unicode', ->
+    it.skip 'should replace unicode', ->
         char_map = {
             '☢':"radioactive",'☠':"skull-and-bones",'☤':"caduceus",
             '☣':"biohazard",'☭':"hammer-and-sickle", '☯':"yin-yang",'☮':"peace",
@@ -215,7 +215,7 @@ describe 'slug', ->
     it 'should replace lithuanian characters', ->
         slug('ąčęėįšųūžĄČĘĖĮŠŲŪŽ').should.eql 'aceeisuuzACEEISUUZ'
 
-    it 'should replace multichars', ->
+    it.skip 'should replace multichars', ->
         [slug "w/ <3 && sugar || ☠"].should.eql ['with-love-and-sugar-or-skull-and-bones']
 
     it 'should be flavourable', ->


### PR DESCRIPTION
The problem with using this library in server-side node is that it makes HTTP requests to fetch a [unicode lookup table](http://unicode.org/Public/UNIDATA/UnicodeData.txt). Server-side node modules should not be implicitly making outbound requests. Caching this file isn't a good solution either, because this file is 1.6 MB, and we don't want to incur the cost of reading this file into memory every time we load the module.

Another problem is that the original module only parses the [So](https://github.com/suisha/node-slug/blob/master/slug.js#L6) category of unicode, and not the entirety. This excludes the majority of unicode characters.

To solve these problems, I've done the following:
1. Use the [unidecode](https://github.com/FGRibreau/node-unidecode) library to parse unicode instead. This library lacks the ability to [parse any unicode characters above `U+FFFF`](http://search.cpan.org/~sburke/Text-Unidecode-1.27/lib/Text/Unidecode.pm#TODO) (meaning no emojis), but that's not a requirement for many use cases.
2. CommonJS only: since this feature won't work in AMD/script tag, I removed compatibility.
